### PR TITLE
Fix environment variable assignment in workflow

### DIFF
--- a/.github/workflows/linux-ninja-gcc.yml
+++ b/.github/workflows/linux-ninja-gcc.yml
@@ -32,7 +32,7 @@ jobs:
         shell: bash
         run: |
           ncore=`nproc`
-          echo "CMAKE_BUILD_PARALLEL_LEVEL=$ncore" >> GITHUB_ENV
+          echo "CMAKE_BUILD_PARALLEL_LEVEL=$ncore" >> $GITHUB_ENV
           echo "CTEST_PARALLEL_LEVEL=$ncore" >> $GITHUB_ENV
       - name: Install prerequisites
         shell: bash


### PR DESCRIPTION
The `CMAKE_BUILD_PARALLEL_LEVEL` env var was not set properly since the write was not done to the `$GITHUB_ENV` variable but to a file with `GITHUB_ENV` name.